### PR TITLE
Fix uni name and links

### DIFF
--- a/_posts/2020-07-09-stephan-druskat.md
+++ b/_posts/2020-07-09-stephan-druskat.md
@@ -4,7 +4,7 @@ title: "Language shapes reality"
 author: "@pweschmidt"
 rse: "Stephan Druskat"
 phenotype: sdruskat-rse-phenotype.png
-excerpt: "Meet Stephan Druskat, RSE at the Alexander von Humboldt University in Berlin, Germany. Listen to Stephan explain his exciting work for research in linguistics and his contributions to making software citable."
+excerpt: "Meet Stephan Druskat, RSE at the Humboldt University in Berlin, Germany. Listen to Stephan explain his exciting work for research in linguistics and his contributions to making software citable."
 date: 2020-07-09 8:30:00
 external_media: https://us-rse.org/rse-stories-episodes-1/2020/rse-stories-stephan-druskat-episode-24.mp3
 length: 19032316
@@ -12,20 +12,22 @@ duration: "00:39:39"
 explicit: "no"
 resources:
  - name: Stephan Druskat
- - url: https://sdruskat.net
+   url: https://sdruskat.net
  - name: Stephan Druskat Twitter
    url:  https://twitter.com/stdruskat
- - name: Alexander von Humboldt University
+ - name: Humboldt University
    url: https://www.informatik.hu-berlin.de/en/standardseite-en?set_language=en
  - name: MelaTAMP project (linguistics)
    url: https://www.projekte.hu-berlin.de/en/melatamp
  - name: RSE DE in Digital Humanities
    url: https://dh-rse.github.io
+ - name: de-RSE e.V. - Society for Research Software
+   url: https://de-rse.org/en/
 ---
 
 Today we go to Berlin in Germany to meet with Stephan Druskat ([@sdruskat](https://github.com/sdruskat)). Stephan is a research software engineer at
-the [Alexander-von-Humboldt Universität in Berlin](https://www.informatik.hu-berlin.de/).
+the [Humboldt-Universität zu Berlin](https://www.informatik.hu-berlin.de/).
 He has been involved with a lot of exciting research on
-linguistics, such as the study of oceanic languages (https://www.projekte.hu-berlin.de/en/melatamp).
+linguistics, such as the study of Oceanic languages (https://www.projekte.hu-berlin.de/en/melatamp).
 Another focus of his work has been "software citation" and ensuring that software becomes a valid and recognised output of research [[ref]](https://elib.dlr.de/133021/1/druskat-cise-2019.pdf).
-And if that isn't enough, Stephan plays an important part in building the [RSE community in Germany](https://dh-rse.github.io).
+And if that isn't enough, Stephan plays an important part in building the [RSE community in Germany](https://de-rse.org/en/).


### PR DESCRIPTION
- Remove "Alexander von" from Humboldt uni, as it's called just Humboldt uni, referencing both brothers :)
- Add link to de-RSE (the German RSE assoc) in addition to DH-RSE (just digital humanities)
- Fix link in free text
- Remove surplus dash in resources list