### PR TITLE
Fix opengraph metadata tags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,8 +21,8 @@
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
 
-  <meta property="og:title" content="RSE Stories" />
-  <meta property="og:description" content="Research Software Engineer Stories">
+  <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}RSE Stories{% endif %}" />
+  <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt }}{% else %}Research Software Engineer Stories{% endif %}">
   <meta property="og:type" content="website" />  
   <meta property="og:url" content="{{ site.url }}{{ site.baseurl }}" />  
   <meta property="og:image" content="{{ site.url }}{{ site.baseurl }}/logo/rse-stories-real-small.png" />


### PR DESCRIPTION
Changed the opengraph metadata tags to produce the same value as the twitter metadata tags. This will make the embedding of RSE stories episodes look better on platforms that read the opengraph tags, such as slack and discord.

Disclaimer:
- Only fixes "og:" tags. The single meta "description" tag was left unchanged.
- I have not tested this locally.