### PR TITLE
Add SC22 Mini-series episode: ECP Past Participants

### DIFF
--- a/_posts/2022-07-14-past-ecp-participants.md
+++ b/_posts/2022-07-14-past-ecp-participants.md
@@ -1,0 +1,39 @@
+---
+layout: post
+title: "SC22 Mini-series: ECP Past Participants"
+author: "@mmundt"
+rse: "Sameh Abdulah, Jean Luca Bez, Silvina Caino-Lores, Hang Liu, Valeria Barra, Bashir Mohammed"
+excerpt: "Six past Early Career Program participants tell us about their experiences in the program and why others should apply as part of Supercomputing 2022."
+date: "2022-07-14 4:30:00"
+external_media: 
+length: 27761749
+duration: "00:47:09"
+explicit: "no"
+resources:
+  - name: Supercomputing 2022
+    url: https://sc22.supercomputing.org/
+  - name: SC22 Early Career Program
+    url: https://sc22.supercomputing.org/program/early-career/
+  - name: SC22 ECP Applications
+    url: https://sc22.supercomputing.org/submit/early-career-applications/
+  - name: The Early Career Program Helped Four Young Professionals Thrive and You Can Too
+    url: https://sc22.supercomputing.org/2022/06/11/the-early-career-program-helped-four-young-professionals-thrive-and-you-can-too/
+--- 
+
+Last time in the SC22 Mini-series, we learned about the Early Career Program (ECP)
+from its chair, Marina Kraeva. Today we get a first-hand glimpse into what the program can
+offer its attendees as we talk to six previous ECP participants.
+
+Our six guests in this episode are Sameh Abdulah, Jean Luca Bez, Silvina Caino-Lores,
+Hang Liu, Valeria Barra, and Bashir Mohammed. In a mix of one-on-one and panel interviews,
+these past attendees tell us how ECP taught them valuable professional
+lessons from funding to time management to mentor-mentee relationship building,
+as well as created lasting connections and a sense of community with a network of both their peers and
+more senior scientists and reseachers.
+
+All participants encourage any professionals in their early career to apply for
+the program this year, taking place in Dallas, TX, as part of Supercomputing 2022. To apply,
+visit the [Early Career Program page](https://sc22.supercomputing.org/submit/early-career-applications/).
+
+As a bonus, two of our interviewees also spoke to Marina Kraeva for an SC22 blog
+post! Check it out on the [SC22 Blog Posts Page](https://sc22.supercomputing.org/2022/06/11/the-early-career-program-helped-four-young-professionals-thrive-and-you-can-too/).

--- a/_posts/2022-07-14-past-ecp-participants.md
+++ b/_posts/2022-07-14-past-ecp-participants.md
@@ -29,7 +29,7 @@ Hang Liu, Valeria Barra, and Bashir Mohammed. In a mix of one-on-one and panel i
 these past attendees tell us how ECP taught them valuable professional
 lessons from funding to time management to mentor-mentee relationship building,
 as well as created lasting connections and a sense of community with a network of both their peers and
-more senior scientists and reseachers.
+more senior scientists and researchers.
 
 All participants encourage any professionals in their early career to apply for
 the program this year, taking place in Dallas, TX, as part of Supercomputing 2022. To apply,

--- a/_posts/2022-07-14-past-ecp-participants.md
+++ b/_posts/2022-07-14-past-ecp-participants.md
@@ -5,7 +5,7 @@ author: "@mmundt"
 rse: "Sameh Abdulah, Jean Luca Bez, Silvina Caino-Lores, Hang Liu, Valeria Barra, Bashir Mohammed"
 excerpt: "Six past Early Career Program participants tell us about their experiences in the program and why others should apply as part of Supercomputing 2022."
 date: "2022-07-14 4:30:00"
-external_media: 
+external_media: https://raw.githubusercontent.com/USRSE/rse-stories-episodes-1/master/2022/rse-stories-ecp-participants-mini-series-miranda-3.mp3
 length: 27761749
 duration: "00:47:09"
 explicit: "no"


### PR DESCRIPTION
As before, the audio file is in the Google drive! This episode features six previous participants in the Early Career Program at Supercomputing.